### PR TITLE
tweak(midi): make get_duration a sync function

### DIFF
--- a/ext/midi.py
+++ b/ext/midi.py
@@ -80,7 +80,7 @@ LETTER_PITCH_MAP = {
 log = logging.getLogger(__name__)
 
 
-async def get_duration(letter):
+def get_duration(letter):
     return {
         ' ': 2,
         ',': 3,
@@ -105,7 +105,7 @@ class MIDI(Cog):
             # modifiers are characters before the actual
             # letter note that modify the note's duration
             try:
-                duration = await get_duration(data[index - 1])
+                duration = get_duration(data[index - 1])
             except IndexError:
                 duration = 1
 


### PR DESCRIPTION
doesn't really make sense to be async since it's not calling any other coroutines