### PR TITLE
coins+: add an alias to stealstate

### DIFF
--- a/ext/coins+.py
+++ b/ext/coins+.py
@@ -411,7 +411,7 @@ class CoinsExt(Cog, requires=['coins']):
             self.coins.unlock_account(thief.id)
             self.coins.unlock_account(target.id)
 
-    @commands.command()
+    @commands.command(aliases=['stealstatus'])
     async def stealstate(self, ctx):
         """Show your current state in the stealing business.
 


### PR DESCRIPTION
I keep confusing "stealstate" with "stealstatus". 

I asked for it to be aliased, and was told to send a PR... here it is.